### PR TITLE
Add support for azurerm 2.x and azurecaf providers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+{
+    "name": "Azure CAF rover",
+ 
+    // Update the 'dockerComposeFile' list if you have more compose files or use different names.
+    "dockerComposeFile": "docker-compose.yml",
+ 
+    // The 'service' property is the name of the service for the container that VS Code should
+    // use. Update this value and .devcontainer/docker-compose.yml to the real service name.
+    "service": "rover",
+ 
+    // The optional 'workspaceFolder' property is the path VS Code should open by default when
+    // connected. This is typically a volume mount in .devcontainer/docker-compose.yml
+    "workspaceFolder": "/tf/caf",
+ 
+    // Use 'settings' to set *default* container specific settings.json values on container create. 
+    // You can edit these settings after create using File > Preferences > Settings > Remote.
+    "settings": { 
+        // If you are using an Alpine-based image, change this to /bin/ash
+        "terminal.integrated.shell.linux": "/bin/bash"
+    },
+ 
+    // Uncomment the next line if you want start specific services in your Docker Compose config.
+    // "runServices": [],
+ 
+    // Uncomment this like if you want to keep your containers running after VS Code shuts down.
+    // "shutdownAction": "none",
+ 
+    // Uncomment the next line to run commands after the container is created.
+    "postCreateCommand": "cp -R /tmp/.ssh-localhost/* ~/.ssh && chmod 700 ~/.ssh && chmod 600 ~/.ssh/*",
+ 
+    // Add the IDs of extensions you want installed when the container is created in the array below.
+    "extensions": [
+        "4ops.terraform",
+        "mutantdino.resourcemonitor"
+    ]
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,28 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+ 
+  version: '3.7'
+  services:
+    rover:
+      image: aztfmod/roverdev:2003.200951
+    
+      labels:
+        - "caf=Azure CAF"
+   
+      volumes:
+        # This is where VS Code should expect to find your project's source code
+        # and the value of "workspaceFolder" in .devcontainer/devcontainer.json
+        - ..:/tf/caf
+        - volume-caf-vscode:/home/vscode
+        - ~/.ssh:/tmp/.ssh-localhost:ro
+        - /var/run/docker.sock:/var/run/docker.sock 
+   
+      # Overrides default command so things don't shut down after the process ends.
+      command: /bin/sh -c "while sleep 1000; do :; done" 
+   
+  volumes:
+    volume-caf-vscode:
+      labels:
+        - "caf=Azure CAF"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,7 +6,7 @@
   version: '3.7'
   services:
     rover:
-      image: aztfmod/roverdev:2003.200951
+      image: aztfmod/rover:2003.2503
     
       labels:
         - "caf=Azure CAF"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## v2.0 (March 2020)
+
+FEATURES: 
+* **new feature:**  Add support for azurerm 2.x and azurecaf providers ([#6](https://github.com/aztfmod/terraform-azurerm-caf-activity-logs/issues/6))
+
+
+IMPROVEMENTS:
+
+BUGS:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ module "activity_logs" {
 | Name | Type | Default | Description |
 | -- | -- | -- | -- |
 | resource_group_name | string | None | (Required) Name of the resource group where to create the resource. Changing this forces a new resource to be created. |
+| name | string | None | (Required) Name for the objects created (before naming convention applied.) |
 | location | string | None | (Required) Specifies the Azure location to deploy the resource. Changing this forces a new resource to be created.  |
 | tags | map | None | (Required) Map of tags for the deployment.  |
 | logs_retention | string | None | (Required) Number of days to keep the logs for long term retention (storage account)  |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Gitter](https://badges.gitter.im/aztfmod/community.svg)](https://gitter.im/aztfmod/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+
 # Configures the Azure Activity Logs for a subscription
 
 Configures the Azure Activity Logs rention for a subscription into:
@@ -34,7 +35,7 @@ module "activity_logs" {
 | max_length | string | None | (Optional) maximum length to the name of the resource. |
 
 
-# Outputs
+## Outputs
 
 | Name | Type | Description | 
 | -- | -- | -- | 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build status](https://dev.azure.com/azure-terraform/Blueprints/_apis/build/status/modules/activity_logs)](https://dev.azure.com/azure-terraform/Blueprints/_build/latest?definitionId=7)
+[![Gitter](https://badges.gitter.im/aztfmod/community.svg)](https://gitter.im/aztfmod/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 # Configures the Azure Activity Logs for a subscription
 
 Configures the Azure Activity Logs rention for a subscription into:
@@ -15,113 +15,23 @@ module "activity_logs" {
     location              = var.locations
     tags                  = var.tags
     prefix                = var.prefix
-    logs_rentention       = var.retention
+    logs_retention       = var.retention
 }
 ```
+## Inputs 
 
-# Parameters
+| Name | Type | Default | Description |
+| -- | -- | -- | -- |
+| resource_group_name | string | None | (Required) Name of the resource group where to create the resource. Changing this forces a new resource to be created. |
+| location | string | None | (Required) Specifies the Azure location to deploy the resource. Changing this forces a new resource to be created.  |
+| tags | map | None | (Required) Map of tags for the deployment.  |
+| logs_retention | string | None | (Required) Number of days to keep the logs for long term retention (storage account)  |
+| enable_event_hub | boolean | true | (Optional) Determine to deploy Event Hub for the configuration. |
+| convention | string | None | (Required) Naming convention to be used (check at the naming convention module for possible values).  |
+| prefix | string | None | (Optional) Prefix to be used. |
+| postfix | string | None | (Optional) Postfix to be used. |
+| max_length | string | None | (Optional) maximum length to the name of the resource. |
 
-## resource_group_name
-(Required) (Required) Name of the resource group to deploy the activity logs.
-```hcl
-variable "resource_group_name" {
-  description = "(Required) Name of the resource group to deploy the activity logs."
-}
-
-```
-Example
-```hcl
-    resource_group_name   = "myrg" 
-```
-
-## location
-(Required) Define the region where the resources will be created
-```hcl
-variable "location" {
-  description = "(Required) Define the region where the resources will be created"
-}
-```
-Example
-```hcl
-    location   = "southeastasia"
-```
-
-## tags
-(Required) Map of tags for the deployment
-```hcl
-variable "tags" {
-  description = "(Required) map of tags for the deployment"
-}
-```
-Example
-```hcl
-tags = {
-    environment     = "DEV"
-    owner           = "Arnaud"
-    deploymentType  = "Terraform"
-  }
-```
-
-## prefix
-(Optional) You can use a prefix to add to the list of resource groups you want to create
-```hcl
-variable "prefix" {
-    description = "(Optional) You can use a prefix to add to the list of resource groups you want to create"
-}
-```
-Example
-```hcl
-locals {
-    prefix = "${random_string.prefix.result}-"
-}
-
-resource "random_string" "prefix" {
-    length  = 4
-    upper   = false
-    special = false
-}
-```
-
-## logs_rentention
-(Required) Number of days to keep the logs for long term retention (storage account)
-```hcl
-variable "logs_rentention" {
-  description = "(Required) Number of days to keep the logs for long term retention"
-}
-```
-Example
-```hcl
-logs_rentention = 60
-
-
-```
-
-## enable_event_hub 
-(Optional) Determine to deploy Event Hub for the configuration
-```hcl
-variable "enable_event_hub" {
-  description = "(Optional) Determine to deploy Event Hub for the configuration"
-  default = true
-}
-```
-
-Example
-```hcl
-enable_event_hub = false
-
-```
-
-## convention
-(Required) Naming convention to be used.
-```hcl
-variable "convention" {
-  description = "(Required) Naming convention used"
-}
-```
-Example
-```hcl
-convention = "cafclassic"
-```
 
 # Outputs
 

--- a/examples/activity_logs/activity_logs.tf
+++ b/examples/activity_logs/activity_logs.tf
@@ -1,10 +1,7 @@
-module "rg_test" {
-  source  = "aztfmod/caf-resource-group/azurerm"
-  version = "0.1.1"
-  
-    prefix          = local.prefix
-    resource_groups = local.resource_groups
-    tags            = local.tags
+resource "azurerm_resource_group" "rg_test" {
+  name     = local.resource_groups.test.name
+  location = local.resource_groups.test.location
+  tags     = local.tags
 }
 
 module "al_test" {
@@ -17,7 +14,7 @@ module "al_test" {
     prefix              = local.prefix
     tags                = local.tags
 
-    resource_group_name = module.rg_test.names.test
+    resource_group_name = azurerm_resource_group.rg_test.name
     
     logs_rentention     = local.azure_activity_logs_retention
     enable_event_hub    = local.azure_activity_logs_event_hub

--- a/examples/activity_logs/locals.tf
+++ b/examples/activity_logs/locals.tf
@@ -1,5 +1,5 @@
 locals {
-    convention = "random"
+    convention = "cafrandom"
     name = "caftest"
     location = "southeastasia"
     prefix = "test"

--- a/examples/activity_logs/main.tf
+++ b/examples/activity_logs/main.tf
@@ -1,0 +1,5 @@
+provider "azurerm" {
+  version = "~>2.2.0"
+  features {}
+}
+

--- a/module.tf
+++ b/module.tf
@@ -1,26 +1,21 @@
 # Defines the subscription-wide logging and eventing settings
 # Creating the containers on Storage Account and Event Hub (optional)
-
-module "caf_name_st" {
-  source  = "aztfmod/caf-naming/azurerm"
-  version = "~> 0.1.0"
-  
+resource "azurecaf_naming_convention" "caf_name_st" {  
   name    = var.name
-  type    = "st"
+  prefix  = var.prefix != "" ? var.prefix : null
+  resource_type    = "st"
   convention  = var.convention
 }
 
-module "caf_name_evh" {
-  source  = "aztfmod/caf-naming/azurerm"
-  version = "~> 0.1.0"
-
+resource "azurecaf_naming_convention" "caf_name_evh" {  
   name    = var.name
-  type    = "evh"
+  prefix  = var.prefix != "" ? var.prefix : null
+  resource_type    = "evh"
   convention  = var.convention
 }
 
 resource "azurerm_storage_account" "log" {
-  name                      = module.caf_name_st.st
+  name                      = azurecaf_naming_convention.caf_name_st.result
   resource_group_name       = var.resource_group_name
   location                  = var.location
   account_kind              = "StorageV2"
@@ -34,7 +29,7 @@ resource "azurerm_storage_account" "log" {
 resource "azurerm_eventhub_namespace" "log" {
   count = var.enable_event_hub ? 1 : 0 
   
-  name                    = module.caf_name_evh.evh
+  name                    = azurecaf_naming_convention.caf_name_evh.result
   location                = var.location
   resource_group_name     = var.resource_group_name
   sku                     = "Standard"

--- a/module.tf
+++ b/module.tf
@@ -3,13 +3,17 @@
 resource "azurecaf_naming_convention" "caf_name_st" {  
   name    = var.name
   prefix  = var.prefix != "" ? var.prefix : null
-  resource_type    = "st"
+  postfix       = var.postfix != "" ? var.postfix : null
+  max_length    = var.max_length != "" ? var.max_length : null
+  resource_type    = "azurerm_storage_account"
   convention  = var.convention
 }
 
 resource "azurecaf_naming_convention" "caf_name_evh" {  
   name    = var.name
   prefix  = var.prefix != "" ? var.prefix : null
+  postfix       = var.postfix != "" ? var.postfix : null
+  max_length    = var.max_length != "" ? var.max_length : null
   resource_type    = "evh"
   convention  = var.convention
 }
@@ -51,7 +55,7 @@ resource "azurerm_monitor_log_profile" "subscription" {
 
 # Add all regions - > put in variable
 # az account list-locations --query '[].name' 
-# updated Dec 15 2019 
+# updated Dec 15 2019 checked March 2020
   locations = [
   "global",
   "eastasia",

--- a/variables.tf
+++ b/variables.tf
@@ -10,9 +10,6 @@ variable "tags" {
   description = "(Required) Tags for the logs repositories to be created "
   
 }
-variable "prefix" {
-  description = "(Optional) You can use a prefix to add to the list of resource groups you want to create"
-}
 
 variable "logs_rentention" {
   description = "(Required) Number of days to keep the logs for long term retention"
@@ -29,5 +26,23 @@ variable "convention" {
 
 variable "name" {
   description = "(Required) Name for the objects created (before naming convention applied.)"    
+}
+
+variable "prefix" {
+  description = "(Optional) You can use a prefix to the name of the resource"
+  type        = string
+  default = ""
+}
+
+variable "postfix" {
+  description = "(Optional) You can use a postfix to the name of the resource"
+  type        = string
+  default = ""
+}
+
+variable "max_length" {
+  description = "(Optional) You can speficy a maximum length to the name of the resource"
+  type        = string
+  default = ""
 }
 


### PR DESCRIPTION
## v2.0 (March 2020)

FEATURES: 
* **new feature:**  Add support for azurerm 2.x and azurecaf providers ([#6](https://github.com/aztfmod/terraform-azurerm-caf-activity-logs/issues/6))
